### PR TITLE
chore: fixed ts-node not working

### DIFF
--- a/generateCsv/package.json
+++ b/generateCsv/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
`ts-node` not working if `"type"` of `package.json` is `"module"`.