### PR TITLE
chore: test/e2e の依存も renovate の管理対象に含める

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "minimumReleaseAge": "7 days"
+  "minimumReleaseAge": "7 days",
+  "ignorePaths": ["**/node_modules/**"]
 }


### PR DESCRIPTION
`config:recommended`が継承する`:ignoreModulesAndTests`のデフォルト`ignorePaths`に`**/test/**`が含まれており、`test/e2e/package.json`が renovate のスキャン対象から外れていた。
`ignorePaths`を自前で`["**/node_modules/**"]`に上書きすることで、`test/e2e`配下の依存も renovate で管理されるようにする。
