### PR TITLE
chore: TypeScript の Renovate PR には build 接頭辞を付ける

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "minimumReleaseAge": "7 days",
-  "ignorePaths": ["**/node_modules/**"]
+  "ignorePaths": ["**/node_modules/**"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["typescript"],
+      "semanticCommitType": "build"
+    }
+  ]
 }


### PR DESCRIPTION
TypeScript のバージョンを上げると`tsc`の出力、つまり配布物に差が生まれ、 Ken All 自体のバージョンも上げる必要がある。
そしてコミットメッセージの接頭辞が`chore`だと、「バージョンを上げるべき対象」として release-please に認識してもらえないので、`chore`ではなく`build`を付けるように設定する。
