### PR TITLE
fix: 配布パッケージに esm/ が含まれない問題を修正する

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,14 @@ jobs:
         with:
           node-version: 24
 
-      # prepublishOnly が npm ci とビルドを実行する。認証は OIDC（トークン設定なし）
+      # .npmrc の ignore-scripts=true により prepublishOnly は実行されないため、明示的にビルドする
+      - name: Build
+        run: npm run build
+
+      # 空パッケージの公開を防ぐ。ビルド成果物がなければここで止まる
+      - name: Check build output
+        run: test -f esm/index.js && test -f esm/index.d.ts
+
+      # 認証は OIDC（トークン設定なし）
       - name: Publish to npm
         run: npm publish


### PR DESCRIPTION
現在、`.npmrc`で`ignore-scripts=true`を設定している。
https://github.com/numb86/ken-all/blob/9fd3a0d8c506064f398b993691c03f920a6d2a77/.npmrc#L2

この設定があると`prepublishOnly`が実行されなくなる。
これにより配布物が意図したものでは無くなってしまっていたため、修正する。